### PR TITLE
Clarify react-native dependency to be >=0.47.0, < 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "rfc4648": "^0.9.1"
   },
   "peerDependencies": {
-    "react-native": "^0.47.0"
+    "react-native": ">=0.47.0 <1.0.0"
   },
   "devDependencies": {
     "babel-preset-react-native": "3.0.2",


### PR DESCRIPTION
For 1.0.0 and above, caret means "matches major version",
but for 0.x.0 and above, caret means "matches major and minor version".

It's clear from usage that the intention for this dependency is to match
the looser 1.0.0 caret usage. This change matches that, enabling explicit
compatibility with react-native releases from the past 8 months.

https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004
https://www.npmjs.com/package/react-native